### PR TITLE
Merge staging to prod - Bump org.postgresql:postgresql from 42.3.8 to 42.7.2 in /finish/modul…

### DIFF
--- a/finish/module-persisting-data/pom.xml
+++ b/finish/module-persisting-data/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.6.0</version>
+            <version>42.7.2</version>
             <scope>provided</scope>
         </dependency>
         <!-- end::postgresql[] -->        

--- a/finish/module-testcontainers/pom.xml
+++ b/finish/module-testcontainers/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>42.3.8</version>
+            <version>42.7.2</version>
             <scope>provided</scope>
         </dependency>
         
@@ -133,7 +133,7 @@
                             <dependency>
                                 <groupId>org.postgresql</groupId>
                                 <artifactId>postgresql</artifactId>
-                                <version>42.3.8</version>
+                                <version>42.7.2</version>
                             </dependency>
                         </dependencyGroup>
                     </copyDependencies>


### PR DESCRIPTION
…e-testcontainers (#24)

* Bump org.postgresql:postgresql in /finish/module-persisting-data

Bumps [org.postgresql:postgresql](https://github.com/pgjdbc/pgjdbc) from 42.6.0 to 42.7.2.
- [Release notes](https://github.com/pgjdbc/pgjdbc/releases)
- [Changelog](https://github.com/pgjdbc/pgjdbc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pgjdbc/pgjdbc/commits)

---
updated-dependencies:
- dependency-name: org.postgresql:postgresql dependency-type: direct:production ...



* Bump org.postgresql:postgresql in /finish/module-testcontainers

Bumps [org.postgresql:postgresql](https://github.com/pgjdbc/pgjdbc) from 42.3.8 to 42.7.2.
- [Release notes](https://github.com/pgjdbc/pgjdbc/releases)
- [Changelog](https://github.com/pgjdbc/pgjdbc/blob/master/CHANGELOG.md)
- [Commits](https://github.com/pgjdbc/pgjdbc/commits)

---
updated-dependencies:
- dependency-name: org.postgresql:postgresql dependency-type: direct:production ...



---------