### PR TITLE
skip test for java 11

### DIFF
--- a/scripts/dailyBuild.sh
+++ b/scripts/dailyBuild.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-while getopts t:d:b:u: flag; do
+while getopts t:d:j: flag; do
     case "${flag}" in
     t) DATE="${OPTARG}" ;;
     d) DRIVER="${OPTARG}" ;;
+    j) JDK_LEVEL="${OPTARG}" ;;
     *) echo "Invalid option" ;;
     esac
 done


### PR DESCRIPTION
Test skipped because the guide does not support Java 11.